### PR TITLE
Adding support for validation rules and fieldsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ DESCRIPTION
      - EmailTemplate
      - EscalationRules
      - FlexiPage
-     - Fieldset
+     - FieldSet
      - GlobalValueSet
      - GlobalValueSetTranslation
      - HomePageLayout

--- a/README.md
+++ b/README.md
@@ -84,10 +84,12 @@ DESCRIPTION
      - EmailTemplate
      - EscalationRules
      - FlexiPage
+     - Fieldset
      - GlobalValueSet
      - GlobalValueSetTranslation
      - HomePageLayout
      - ListView
+     - LightningComponentBundle
      - Layout
      - NamedCredential
      - Network
@@ -102,6 +104,7 @@ DESCRIPTION
      - StandardValueSetTranslation
      - StaticResource
      - Translations
+     - ValidationRule
      - WebLink
      - Workflow
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sfdx-essentials",
   "description": "Tools to cover the lacks of missing required functions of SFDX",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "author": "NicolasVuillamy @nvuillam",
   "bugs": "https://github.com/nvuillam/sfdx-essentials/issues",
   "dependencies": {

--- a/src/common/metadata-utils.ts
+++ b/src/common/metadata-utils.ts
@@ -54,6 +54,8 @@ export class MetadataUtils {
       'ListView': { sobjectRelated: true },
       'RecordType': { sobjectRelated: true },
       'WebLink': { sobjectRelated: true },
+      'ValidationRule': { sobjectRelated: true },
+      'Fieldset': { sobjectRelated: true },
 
       // Special case: Translations, used for object copy and for filtering 
       'Translations': { translationRelated: true, folder: 'translations', nameSuffixList: ['.translation'],sfdxNameSuffixList: ['.translation-meta.xml'] },
@@ -79,7 +81,11 @@ export class MetadataUtils {
       { objectXmlPropName: 'recordTypes', packageXmlPropName: 'RecordType', nameProperty: 'fullName', translationNameProperty: 'name',
         sfdxNameSuffixList: ['.recordType-meta.xml'] },
       { objectXmlPropName: 'webLinks', packageXmlPropName: 'WebLink', nameProperty: 'fullName', translationNameProperty: 'name',
-        sfdxNameSuffixList: ['.webLink-meta.xml'] }
+        sfdxNameSuffixList: ['.webLink-meta.xml'] },
+      { objectXmlPropName: 'validationRules', packageXmlPropName: 'ValidationRule', nameProperty: 'fullName', translationNameProperty: 'name',
+        sfdxNameSuffixList: ['.validationRule-meta.xml'] },
+      { objectXmlPropName: 'fieldSets', packageXmlPropName: 'Fieldset', nameProperty: 'fullName', translationNameProperty: 'name',
+        sfdxNameSuffixList: ['.fieldSet-meta.xml'] }
     ]
     return objectFilteringProperties
   }

--- a/src/common/metadata-utils.ts
+++ b/src/common/metadata-utils.ts
@@ -55,7 +55,7 @@ export class MetadataUtils {
       'RecordType': { sobjectRelated: true },
       'WebLink': { sobjectRelated: true },
       'ValidationRule': { sobjectRelated: true },
-      'Fieldset': { sobjectRelated: true },
+      'FieldSet': { sobjectRelated: true },
 
       // Special case: Translations, used for object copy and for filtering 
       'Translations': { translationRelated: true, folder: 'translations', nameSuffixList: ['.translation'],sfdxNameSuffixList: ['.translation-meta.xml'] },
@@ -84,7 +84,7 @@ export class MetadataUtils {
         sfdxNameSuffixList: ['.webLink-meta.xml'] },
       { objectXmlPropName: 'validationRules', packageXmlPropName: 'ValidationRule', nameProperty: 'fullName', translationNameProperty: 'name',
         sfdxNameSuffixList: ['.validationRule-meta.xml'] },
-      { objectXmlPropName: 'fieldSets', packageXmlPropName: 'Fieldset', nameProperty: 'fullName', translationNameProperty: 'name',
+      { objectXmlPropName: 'fieldSets', packageXmlPropName: 'FieldSet', nameProperty: 'fullName', translationNameProperty: 'name',
         sfdxNameSuffixList: ['.fieldSet-meta.xml'] }
     ]
     return objectFilteringProperties


### PR DESCRIPTION
Hi, we encountered a problem the other day when deploying custom fields, after checking we noticed fieldsets and validations rules were not deleted on the filtered object, so we have added both elements on the metadata-utils and know is working fine. Thanks for the work in the plugin by the way, it's been really helpful for us.