### PR TITLE
2.1.3: Display file generate in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.1.3] - 2020-04-07
+
+### Changed
+
+- console.log added to display permission set file generated with -v option
+
 ## [2.1.2] - 2020-03-25
 
 ### Changed

--- a/src/commands/essentials/permissionset/generate.ts
+++ b/src/commands/essentials/permissionset/generate.ts
@@ -121,6 +121,10 @@ export default class PermissionSetGenerate extends Command {
                     fs.writeFile(outputFilename, formattedPsXml, err3 => {
                         if (!err3) {
                             console.log('      - ' + path.resolve(outputFilename));
+                            if (this.verbose) {
+                                console.log(configName + '.permissionset-meta.xml file:');
+                                console.log(formattedPsXml + '\n');
+                            }
                             resolve();
                         } else {
                             console.error(err3.message);

--- a/test/commands/permissionset/generate.test.ts
+++ b/test/commands/permissionset/generate.test.ts
@@ -5,6 +5,7 @@ describe('essentials:permissionset:generate', () => {
   test
     .stdout()
     .command(['essentials:permissionset:generate',
+      '-v',
       '-c', './test/commands/permissionset/generate-permission-sets-config.json',
       '-p', './test/shared/packagexml/package1.xml',
       '-f', './test/shared/sfdxProject/force-app/main/default',
@@ -18,6 +19,7 @@ describe('(alias) essentials:generate-permission-sets', () => {
   test
     .stdout()
     .command(['essentials:generate-permission-sets',
+      '-v',
       '-c', './test/commands/permissionset/generate-permission-sets-config.json',
       '-p', './test/shared/packagexml/package1.xml',
       '-f', './test/shared/sfdxProject/force-app/main/default',


### PR DESCRIPTION
## Fixes

  -
  -

## Proposed Changes

  - Display permission set file generated in log when we use -v option 
  -
  
