### PR TITLE
Send anonymous usage statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# Changelog
+# CHANGELOG
+
+## [2.4.0] - 2020-07-27
+
+- Add anonymous usage stats to improve plugin
+  - your sources are never sent to analytics server ([Amplitude](https://amplitude.com/))
+  - disable with argument **--noinsight**
 
 ## [2.3.1] - 2020-06-22
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "NicolasVuillamy @nvuillam",
   "bugs": "https://github.com/nvuillam/sfdx-essentials/issues",
   "dependencies": {
+    "@amplitude/node": "^0.3.3",
     "@oclif/command": "^1.5.19",
     "@oclif/config": "^1.13.3",
     "@oclif/errors": "^1.2.2",
@@ -19,11 +20,15 @@
     "camelcase": "^5.3.1",
     "cint": "^8.2.1",
     "cli-progress": "^3.5.0",
+    "debug": "^4.1.1",
+    "find-package-json": "^1.2.0",
     "fs": "0.0.1-security",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.6",
+    "minimist": "^1.2.5",
     "path": "^0.12.7",
     "util": "^0.12.1",
+    "uuid": "^8.2.0",
     "xml-formatter": "^1.2.0",
     "xml2js": "^0.4.23"
   },
@@ -33,8 +38,9 @@
     "@oclif/test": "^1.2.5",
     "@salesforce/dev-config": "1.5.0",
     "@types/chai": "^4.2.7",
+    "@types/debug": "^4.1.5",
     "@types/jsforce": "1.9.13",
-    "@types/mocha": "^7.0.1",
+    "@types/mocha": "^7.0.2",
     "@types/node": "^13.7.0",
     "chai": "^4.2.0",
     "globby": "^11.0.0",
@@ -75,6 +81,14 @@
   "oclif": {
     "commands": "./lib/commands",
     "bin": "sfdx",
+    "hooks": {
+      "prerun": [
+        "./lib/hooks/prerun/analytics-init"
+      ],
+      "postrun": [
+        "./lib/hooks/postrun/analytics-send"
+      ]
+    },
     "devPlugins": [
       "@oclif/plugin-help"
     ]
@@ -109,6 +123,7 @@
     "prepack": "rm -rf lib && tsc && oclif-dev manifest",
     "prepare": "rm -rf lib && tsc && oclif-dev manifest",
     "test": "mocha --exit --forbid-only --colors \"test/**/*.test.ts\"",
-    "test:coverage": "nyc npm run test"
+    "test:coverage": "nyc npm run test",
+    "test:debug": "env DEBUG=sfdx-essentials mocha --exit --forbid-only --colors \"test/**/*.test.ts\""
   }
 }

--- a/src/commands/essentials/metadata/filter-from-packagexml.ts
+++ b/src/commands/essentials/metadata/filter-from-packagexml.ts
@@ -82,7 +82,8 @@ sfdx force:mdapi:deploy -d tmp/deployDemoQualiFiltered/ -w 60 -u DemoQuali`
     inputfolder: flags.string({ char: 'i', description: 'Input folder (default: "." )' }),
     outputfolder: flags.string({ char: 'o', description: 'Output folder (default: filteredMetadatas)' }),
     silent: flags.boolean({ char: 's', description: 'Silent logs when no error' }) as unknown as flags.IOptionFlag<boolean>,
-    verbose: flags.boolean({ char: 'v', description: 'Verbose' }) as unknown as flags.IOptionFlag<boolean>
+    verbose: flags.boolean({ char: 'v', description: 'Verbose' }) as unknown as flags.IOptionFlag<boolean>,
+    noinsight: flags.boolean({ description: 'Do not send anonymous usage stats' }) as unknown as flags.IOptionFlag<boolean>
   };
 
   public static args = [];

--- a/src/commands/essentials/metadata/filter-xml-content.ts
+++ b/src/commands/essentials/metadata/filter-xml-content.ts
@@ -24,7 +24,8 @@ This script requires a filter-config.json file`;
     // flag with a value (-n, --name=VALUE)
     configFile: flags.string({ char: 'c', description: 'Config JSON file path' }),
     inputfolder: flags.string({ char: 'i', description: 'Input folder (default: "." )' }),
-    outputfolder: flags.string({ char: 'o', description: 'Output folder (default: parentFolder + _xml_content_filtered)' })
+    outputfolder: flags.string({ char: 'o', description: 'Output folder (default: parentFolder + _xml_content_filtered)' }),
+    noinsight: flags.boolean({ description: 'Do not send anonymous usage stats' }) as unknown as flags.IOptionFlag<boolean>
   };
 
   public static args = [];

--- a/src/commands/essentials/metadata/uncomment.ts
+++ b/src/commands/essentials/metadata/uncomment.ts
@@ -33,7 +33,8 @@ global static List<OrgDebugOption__c> setDebugOption() {
   public static flags = {
     folder: flags.string({ char: 'f', description: 'SFDX project folder containing files' }),
     uncommentKey: flags.string({ char: 'k', description: 'Uncomment key (default: SFDX_ESSENTIALS_UNCOMMENT)' }),
-    verbose: flags.boolean({ char: 'v', description: 'Verbose' }) as unknown as flags.IOptionFlag<boolean>
+    verbose: flags.boolean({ char: 'v', description: 'Verbose' }) as unknown as flags.IOptionFlag<boolean>,
+    noinsight: flags.boolean({ description: 'Do not send anonymous usage stats' }) as unknown as flags.IOptionFlag<boolean>
   };
 
   public static args = [];

--- a/src/commands/essentials/mig/add-namespace.ts
+++ b/src/commands/essentials/mig/add-namespace.ts
@@ -29,7 +29,8 @@ export default class AddNamespace extends Command {
         inputFolder: flags.string({ char: 'i', description: 'Input folder (default: "." )' }),
         fetchExpressionList: flags.string({ char: 'f', description: 'Fetch expression list. Let default if you dont know. ex: ./aura/**/*.js,./aura/**/*.cmp,./classes/*.cls,./objects/*/fields/*.xml,./objects/*/recordTypes/*.xml,./triggers/*.trigger,./permissionsets/*.xml,./profiles/*.xml,./staticresources/*.json' }),
         excludeExpressionList: flags.string({ char: 'e', description: 'List of expressions to ignore. ex: **/node_modules/**' }),
-        verbose: flags.boolean({ char: 'v', description: 'Verbose', default: false }) as unknown as flags.IOptionFlag<boolean>
+        verbose: flags.boolean({ char: 'v', description: 'Verbose', default: false }) as unknown as flags.IOptionFlag<boolean>,
+        noinsight: flags.boolean({ description: 'Do not send anonymous usage stats' }) as unknown as flags.IOptionFlag<boolean>
     };
 
     public static args = [];

--- a/src/commands/essentials/mig/fix-aura-attributes-names.ts
+++ b/src/commands/essentials/mig/fix-aura-attributes-names.ts
@@ -16,7 +16,8 @@ Ex : MyClass_x attribute would be renamed myClassX`;
   ];
 
   public static flags = {
-    folder: flags.string({ char: 'f', description: 'SFDX project folder containing files' })
+    folder: flags.string({ char: 'f', description: 'SFDX project folder containing files' }),
+    noinsight: flags.boolean({ description: 'Do not send anonymous usage stats' }) as unknown as flags.IOptionFlag<boolean>
     // flag with a value (-n, --name=VALUE)
   };
 

--- a/src/commands/essentials/mig/migrate-object-model.ts
+++ b/src/commands/essentials/mig/migrate-object-model.ts
@@ -29,7 +29,8 @@ Use this command if you need to replace a SObject by another one in all your sfd
     deleteFiles: flags.boolean({ char: 'd', description: 'Delete files with deprecated references', default: true, allowNo: true }) as unknown as flags.IOptionFlag<boolean>,
     deleteFilesExpr: flags.boolean({ char: 'k', description: 'Delete files matching expression', default: true, allowNo: true }) as unknown as flags.IOptionFlag<boolean>,
     copySfdxProjectFolder: flags.boolean({ char: 's', description: 'Copy sfdx project files after process', default: true, allowNo: true }) as unknown as flags.IOptionFlag<boolean>,
-    verbose: flags.boolean({ char: 'v', description: 'Verbose', default: false }) as unknown as flags.IOptionFlag<boolean>
+    verbose: flags.boolean({ char: 'v', description: 'Verbose', default: false }) as unknown as flags.IOptionFlag<boolean>,
+    noinsight: flags.boolean({ description: 'Do not send anonymous usage stats' }) as unknown as flags.IOptionFlag<boolean>
   };
 
   public static args = [];

--- a/src/commands/essentials/packagexml/append.ts
+++ b/src/commands/essentials/packagexml/append.ts
@@ -14,7 +14,8 @@ API version number of the result file will be the same than in the first package
         // flag with a value (-n, --name=VALUE)
         packagexmls: flags.string({ char: 'p', description: 'package.xml files path (separated by commas)' }),
         outputfile: flags.string({ char: 'o', description: 'package.xml output file' }),
-        verbose: flags.boolean({ char: 'v', description: 'Verbose', default: false }) as unknown as flags.IOptionFlag<boolean>
+        verbose: flags.boolean({ char: 'v', description: 'Verbose', default: false }) as unknown as flags.IOptionFlag<boolean>,
+        noinsight: flags.boolean({ description: 'Do not send anonymous usage stats' }) as unknown as flags.IOptionFlag<boolean>
     };
 
     public static args = [];

--- a/src/commands/essentials/packagexml/sort.ts
+++ b/src/commands/essentials/packagexml/sort.ts
@@ -16,7 +16,8 @@ export default class PackageXmlSort extends Command {
 
     public static flags = {
         // flag with a value (-n, --name=VALUE)
-        packagexml: flags.string({ char: 'p', description: 'package.xml file path (or a folder containing package.xml files)' })
+        packagexml: flags.string({ char: 'p', description: 'package.xml file path (or a folder containing package.xml files)' }),
+        noinsight: flags.boolean({ description: 'Do not send anonymous usage stats' }) as unknown as flags.IOptionFlag<boolean>
     };
 
     public static args = [];

--- a/src/commands/essentials/permissionset/generate.ts
+++ b/src/commands/essentials/permissionset/generate.ts
@@ -27,7 +27,8 @@ export default class PermissionSetGenerate extends Command {
         sfdxSourcesFolder: flags.string({ char: 'f', description: 'SFDX Sources folder (used to filter required and masterDetail fields)' }),
         nameSuffix: flags.string({ char: 's', description: 'Name suffix for generated permission sets' }),
         outputfolder: flags.string({ char: 'o', description: 'Output folder (default: "." )', default: '.' }),
-        verbose: flags.boolean({ char: 'v', description: 'Verbose', default: false }) as unknown as flags.IOptionFlag<boolean>
+        verbose: flags.boolean({ char: 'v', description: 'Verbose', default: false }) as unknown as flags.IOptionFlag<boolean>,
+        noinsight: flags.boolean({ description: 'Do not send anonymous usage stats' }) as unknown as flags.IOptionFlag<boolean>
     };
 
     // Input params properties
@@ -340,7 +341,7 @@ export default class PermissionSetGenerate extends Command {
         }
         // Manage elements that are in permissionSetDefinition JSON and not in packageXmlTypes
         for (const permissionSetElement of permissionSetDefinition.packageXMLTypeList) {
-            if (!packageXmlTypesArray.includes(permissionSetElement.typeName) && packageXMLTypesAll.includes(permissionSetElement.typeName) ) {
+            if (!packageXmlTypesArray.includes(permissionSetElement.typeName) && packageXMLTypesAll.includes(permissionSetElement.typeName)) {
                 let permissionSetMemberList = [];
                 if (permissionSetElement.includedFilterList && !permissionSetElement.includedFilterList[0].startsWith('(')) {
                     permissionSetMemberList = permissionSetElement.includedFilterList;

--- a/src/commands/essentials/project/change-dependency-version.ts
+++ b/src/commands/essentials/project/change-dependency-version.ts
@@ -31,7 +31,8 @@ export default class ProjectChangeDependencyVersion extends Command {
     apiversion: flags.string({ char: 'a', description: 'If sent, updates api version' }),
     remove: flags.boolean({ char: 'r', description: 'Verbose', default: false }) as unknown as flags.IOptionFlag<boolean>,
     folder: flags.string({ char: 'f', description: 'SFDX project folder containing files' }),
-    verbose: flags.boolean({ char: 'v', description: 'Verbose' }) as unknown as flags.IOptionFlag<boolean>
+    verbose: flags.boolean({ char: 'v', description: 'Verbose' }) as unknown as flags.IOptionFlag<boolean>,
+    noinsight: flags.boolean({ description: 'Do not send anonymous usage stats' }) as unknown as flags.IOptionFlag<boolean>
   };
 
   public static args = [];

--- a/src/commands/essentials/project/check-consistency-with-packagexml.ts
+++ b/src/commands/essentials/project/check-consistency-with-packagexml.ts
@@ -31,7 +31,8 @@ export default class CheckConsistencyWithPackageXml extends Command {
     ignoreDuplicateTypes: flags.string({ char: 'd', default: '', description: 'List of types to ignore while checking for duplicates in package.xml files' }),
     failIfError: flags.boolean({ char: 'f', default: false, description: 'Script failing if errors are founds' }) as unknown as flags.IOptionFlag<boolean>,
     chatty: flags.boolean({ char: 'c', default: false, description: 'Chatty logs' }) as unknown as flags.IOptionFlag<boolean>,
-    jsonLogging: flags.boolean({ char: 'j', default: false, description: 'JSON logs' }) as unknown as flags.IOptionFlag<boolean>
+    jsonLogging: flags.boolean({ char: 'j', default: false, description: 'JSON logs' }) as unknown as flags.IOptionFlag<boolean>,
+    noinsight: flags.boolean({ description: 'Do not send anonymous usage stats' }) as unknown as flags.IOptionFlag<boolean>
   };
 
   // Input params properties

--- a/src/common/analytics.ts
+++ b/src/common/analytics.ts
@@ -1,0 +1,82 @@
+import Amplitude = require('@amplitude/node');
+import Debug from 'debug';
+import os = require('os');
+import path = require('path');
+const debug = Debug('sfdx-essentials');
+
+const AMPLITUDE_TOKEN = 'ec70987c2fddff910b2f53d14f556b59';
+
+let amplitudeClient;
+let pkgJson;
+let anonymousUserId;
+
+// Record anonymous statistics for better use. Returns a promise that can be awaited by the caller or not
+export function recordAnonymousEvent(eventType: string, data: any): Promise<any> {
+    debug('Analytics init: ' + eventType);
+    if (amplitudeClient == null) {
+        amplitudeClient = Amplitude.init(AMPLITUDE_TOKEN);
+    }
+    if (pkgJson == null) {
+        pkgJson = getPackageJson();
+    }
+    if (anonymousUserId == null) {
+        anonymousUserId = getUuidV4();
+    }
+
+    return new Promise(resolve => {
+        const eventPayloadFiltered = buildEventPayload(data);
+        amplitudeClient.logEvent({
+            event_type: eventType,
+            event_properties: eventPayloadFiltered,
+            user_id: anonymousUserId,
+            ip: '127.0.0.1'
+        });
+        debug('Analytics sent: ' + eventType + ' ' + JSON.stringify(eventPayloadFiltered));
+        resolve();
+    });
+}
+
+function buildEventPayload(data: any) {
+    data.app = pkgJson.name;
+    data.appVersion = pkgJson.version;
+    data.osPlatform = os.platform();
+    data.osRelease = os.release();
+    data.ci = process.env.CI ? true : false; // boolean ,
+    return data;
+}
+
+// Retrieve npm-groovy-lint package.json
+function getPackageJson() {
+    const findPackageJson = require('find-package-json');
+    const finder = findPackageJson(__dirname);
+    const packageJsonFileNm = finder.next().filename;
+    let pkg;
+    if (packageJsonFileNm) {
+        pkg = require(packageJsonFileNm);
+    } else {
+        pkg = { name: 'sfdx-essentials', version: '0.0.0' };
+        console.warn(`package.json not found, use default value ${JSON.stringify(pkg)} instead`);
+    }
+    return pkg;
+}
+
+// Get unique anonymous user identifier
+function getUuidV4() {
+    const localStorageFileNm = path.resolve(os.homedir() + '/.node-stats/local-storage.json');
+    const fse = require('fs-extra');
+    let usrLocalStorage = { anonymousUserId: null };
+    if (fse.existsSync(localStorageFileNm)) {
+        usrLocalStorage = fse.readJsonSync(localStorageFileNm);
+    }
+    if (usrLocalStorage.anonymousUserId && usrLocalStorage.anonymousUserId != null) {
+        return usrLocalStorage.anonymousUserId;
+    }
+    const { v4: uuidv4 } = require('uuid');
+    const anonUsrId = uuidv4();
+    usrLocalStorage.anonymousUserId = anonUsrId;
+    fse.ensureDirSync(path.resolve(os.homedir() + '/.node-stats'), { mode: '0777' });
+    fse.writeJsonSync(localStorageFileNm, usrLocalStorage);
+    return usrLocalStorage.anonymousUserId;
+}
+
+module.exports = { recordAnonymousEvent };

--- a/src/hooks/postrun/analytics-send.ts
+++ b/src/hooks/postrun/analytics-send.ts
@@ -1,0 +1,27 @@
+import Debug from 'debug';
+import minimist = require('minimist');
+import { performance } from 'perf_hooks';
+import { recordAnonymousEvent } from '../../common/analytics';
+const debug = Debug('sfdx-essentials');
+
+export const hook = async (data: any) => {
+    const elapsedTimeMs = performance.now() - globalThis.startElapse;
+    globalThis.startElapse = null;
+    if (data.Command == null) {
+        debug('analytics-send: skipped (no command object)');
+        return;
+    }
+    const eventType = data.Command.id;
+    if (eventType == null) {
+        debug('analytics-send: skipped (no command id)');
+        return;
+    }
+    const argss = minimist(data.argv);
+    if (argss.noinsight === true || globalThis.noinsight === true) {
+        debug('analytics-send: skipped (user request)');
+        return;
+    }
+    const analyticsData = { options: argss, elapsedTimeMs };
+    await recordAnonymousEvent(eventType, analyticsData);
+    return;
+};

--- a/src/hooks/prerun/analytics-init.ts
+++ b/src/hooks/prerun/analytics-init.ts
@@ -1,0 +1,5 @@
+import { performance } from 'perf_hooks';
+
+export const hook = async (options: any) => {
+    globalThis.startElapse = performance.now();
+};

--- a/test/helpers/init.js
+++ b/test/helpers/init.js
@@ -1,7 +1,18 @@
 const path = require('path');
 const fs = require('fs');
 process.env.TS_NODE_PROJECT = path.resolve('test/tsconfig.json');
+
+// Create temp dir for tests
 if (!fs.existsSync('./test/tmp')) {
     console.log('Created test/tmp folder');
     fs.mkdirSync('./test/tmp');
+}
+
+// Disable anonymous stats
+globalThis.noinsight = true;
+
+// Activate debug library
+const debug = typeof v8debug === "object" || /--debug|--inspect|--inspect-brk/.test(process.execArgv.join(" "));
+if (debug) {
+    require("debug").enable("sfdx-essentials");
 }


### PR DESCRIPTION
- Add anonymous usage stats to improve plugin
  - your sources are never sent to analytics server ([Amplitude](https://amplitude.com/))
  - disable with argument **--noinsight**
  
